### PR TITLE
Update service.py

### DIFF
--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -89,8 +89,8 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
     def __init__(self, conf):
         super().__init__()
         self.conf = conf
-        self.domain = "demo.eoepca.org"
-        self.workspace_prefix = "demo-user"
+        self.domain = self.conf["eoepca"]["domain"]
+        self.workspace_prefix = self.conf["eoepca"]["workspace_prefix"]
         self.ades_rx_token = self.conf["auth_env"]["jwt"]
         self.feature_collection = None
 
@@ -163,8 +163,6 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
 
         try:
             s3_path = output["StacCatalogUri"]
-            if s3_path.count("s3://")==0:
-                s3_path = "s3://" + s3_path
             cat = read_file( s3_path )
             cat.describe()
         except Exception as e:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -101,7 +101,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
         logger.info("Pre execution hook")
 
         # Workspace API endpoint
-        uri_for_request = f"workspaces/{self.workspace_prefix}-{decoded['user_name']}"
+        uri_for_request = f"workspaces/{self.workspace_prefix}-{decoded['username']}"
 
         workspace_api_endpoint = os.path.join(
             f"https://workspace-api.{self.domain}", uri_for_request
@@ -137,7 +137,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
         decoded = jwt.decode(self.ades_rx_token, options={"verify_signature": False})
 
         # Workspace API endpoint
-        uri_for_request = f"/workspaces/{self.workspace_prefix}-{decoded['user_name']}"
+        uri_for_request = f"/workspaces/{self.workspace_prefix}-{decoded['username']}"
         workspace_api_endpoint = f"https://workspace-api.{self.domain}{uri_for_request}"
 
         # Request: Get Workspace Details
@@ -172,10 +172,10 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             "Authorization": f"Bearer {self.ades_rx_token}",
         }
 
-        api_endpoint = f"https://workspace-api.{self.domain}/workspaces/{self.workspace_prefix}-{decoded['user_name']}"
+        api_endpoint = f"https://workspace-api.{self.domain}/workspaces/{self.workspace_prefix}-{decoded['username']}"
 
         logger.info(
-            f"Register collection in workspace {self.workspace_prefix}-{decoded['user_name']}"
+            f"Register collection in workspace {self.workspace_prefix}-{decoded['username']}"
         )
         collection = next(cat.get_all_collections())
 

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -162,8 +162,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
         logger.info(f"STAC Catalog URI: {output['StacCatalogUri']}")
 
         try:
-            s3_path = output["StacCatalogUri"]
-            cat = read_file( s3_path )
+            cat = read_file( output["StacCatalogUri"] )
             cat.describe()
         except Exception as e:
             logger.error(f"Exception: {e}")

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -162,7 +162,10 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
         logger.info(f"STAC Catalog URI: {output['StacCatalogUri']}")
 
         try:
-            cat = read_file(output["StacCatalogUri"])
+            s3_path = output["StacCatalogUri"]
+            if s3_path.count("s3://")==0:
+                s3_path = "s3://" + s3_path
+            cat = read_file( s3_path )
             cat.describe()
         except Exception as e:
             logger.error(f"Exception: {e}")


### PR DESCRIPTION
The user name is stored in `username` rather than `user_name`.

Side note: the JWT is already parsed before the service is run. Hence, I think it would be better to rely on the `user` field from the `auth_env` section that contains the username, whatever the name of the key storing the user name.

Maybe we should search for the presence of the substring `user` and `name` in a key rather than relying on username, like we do by now for parsing the JWT from the [filter_in process](https://github.com/ZOO-Project/ZOO-Project/blob/main/zoo-project/zoo-services/utils/security/jwt/cgi-env/security_service.py#L58).