### PR TITLE
Fixes for workspace-api integration

### DIFF
--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -95,8 +95,12 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
 
         eoepca = self.conf.get("eoepca", {})
         self.domain = eoepca.get("domain", "")
+        self.workspace_url = eoepca.get("workspace_url", "")
         self.workspace_prefix = eoepca.get("workspace_prefix", "")
-        self.use_workspace = bool(self.workspace_prefix)
+        if self.workspace_url and self.workspace_prefix:
+            self.use_workspace = True
+        else:
+            self.use_workspace = False
 
         auth_env = self.conf.get("auth_env", {})
         self.ades_rx_token = auth_env.get("jwt", "")
@@ -124,9 +128,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 # Workspace API endpoint
                 uri_for_request = f"workspaces/{self.workspace_prefix}-{self.username}"
 
-                workspace_api_endpoint = os.path.join(
-                    f"https://workspace-api.{self.domain}", uri_for_request
-                )
+                workspace_api_endpoint = os.path.join(self.workspace_url, uri_for_request)
 
                 # Request: Get Workspace Details
                 headers = {
@@ -236,7 +238,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                     "Accept": "application/json",
                     "Authorization": f"Bearer {self.ades_rx_token}",
                 }
-                api_endpoint = f"https://workspace-api.{self.domain}/workspaces/{self.workspace_prefix}-{self.username}"
+                api_endpoint = f"{self.workspace_url}/workspaces/{self.workspace_prefix}-{self.username}"
                 r = requests.post(
                     f"{api_endpoint}/register-json",
                     json=collection_dict,

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -140,7 +140,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 }
                 logger.info(f"zzz: workspace_api_endpoint = {workspace_api_endpoint}")
                 logger.info(f"zzz: headers = {headers}")
-                get_workspace_details_response = requests.get(workspace_api_endpoint, headers=headers)
+                get_workspace_details_response = requests.get(workspace_api_endpoint, headers=headers, proxies={})
 
                 # GOOD response from Workspace API - use the details
                 if get_workspace_details_response.ok:
@@ -252,18 +252,19 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                     f"{api_endpoint}/register-json",
                     json=collection_dict,
                     headers=headers,
+                    proxies={},
                 )
                 logger.info(f"Register collection response: {r.status_code}")
 
                 # TODO pool the catalog until the collection is available
                 #self.feature_collection = requests.get(
-                #    f"{api_endpoint}/collections/{collection.id}", headers=headers
+                #    f"{api_endpoint}/collections/{collection.id}", headers=headers, proxies={}
                 #).json()
             
                 logger.info(f"Register processing results to collection")
                 r = requests.post(f"{api_endpoint}/register",
                                 json={"type": "stac-item", "url": collection.get_self_href()},
-                                headers=headers,)
+                                headers=headers, proxies={})
                 logger.info(f"Register processing results response: {r.status_code}")
 
         except Exception as e:
@@ -275,13 +276,15 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             self.restore_http_proxy_env()
 
     def unset_http_proxy_env(self):
-        http_proxy = os.environ.pop("HTTP_PROXY", None)
-        logger.info(f"Unsetting env HTTP_PROXY, whose value was {http_proxy}")
+        # http_proxy = os.environ.pop("HTTP_PROXY", None)
+        # logger.info(f"Unsetting env HTTP_PROXY, whose value was {http_proxy}")
+        pass
 
     def restore_http_proxy_env(self):
-        if self.http_proxy_env:
-            os.environ["HTTP_PROXY"] = self.http_proxy_env
-            logger.info(f"Restoring env HTTP_PROXY, to value {self.http_proxy_env}")
+        # if self.http_proxy_env:
+        #     os.environ["HTTP_PROXY"] = self.http_proxy_env
+        #     logger.info(f"Restoring env HTTP_PROXY, to value {self.http_proxy_env}")
+        pass
 
     @staticmethod
     def init_config_defaults(conf):

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -133,9 +133,12 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                     "accept": "application/json",
                     "Authorization": f"Bearer {self.ades_rx_token}",
                 }
-                workspace_response = requests.get(
+                tmp_response = requests.get(
                     workspace_api_endpoint, headers=headers
-                ).json()
+                )
+                logger.info(f"zzz - response code = {tmp_response.status_code}")
+                logger.info(f"zzz - response text = {tmp_response.text}")
+                workspace_response = tmp_response.json()
 
                 logger.info("Set user bucket settings")
 

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -152,7 +152,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 else:
                     logger.error("Problem connecting with the Workspace API")
                     logger.info(f"  Response code = {get_workspace_details_response.status_code}")
-                    logger.info(f"  Response text = {get_workspace_details_response.text}")
+                    logger.info(f"  Response text = \n{get_workspace_details_response.text}")
                     self.use_workspace = False
                     logger.info("Using pre-configured storage details")
             else:
@@ -274,7 +274,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
         conf["additional_parameters"]["STAGEOUT_AWS_ACCESS_KEY_ID"] = os.environ.get("STAGEOUT_AWS_ACCESS_KEY_ID", "minio-admin")
         conf["additional_parameters"]["STAGEOUT_AWS_SECRET_ACCESS_KEY"] = os.environ.get("STAGEOUT_AWS_SECRET_ACCESS_KEY", "minio-secret-password")
         conf["additional_parameters"]["STAGEOUT_AWS_REGION"] = os.environ.get("STAGEOUT_AWS_REGION", "RegionOne")
-        conf["additional_parameters"]["STAGEOUT_OUTPUT"] = os.environ.get("STAGEOUT_OUTPUT", "s3://processingresults")
+        conf["additional_parameters"]["STAGEOUT_OUTPUT"] = os.environ.get("STAGEOUT_OUTPUT", "processingresults")
 
         # DEBUG
         # logger.info(f"init_config_defaults: additional_parameters...\n{json.dumps(conf['additional_parameters'], indent=2)}\n")

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -132,14 +132,13 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 uri_for_request = f"workspaces/{self.workspace_prefix}-{self.username}"
 
                 workspace_api_endpoint = os.path.join(self.workspace_url, uri_for_request)
+                logger.info(f"Using Workspace API endpoint {workspace_api_endpoint}")
 
                 # Request: Get Workspace Details
                 headers = {
                     "accept": "application/json",
                     "Authorization": f"Bearer {self.ades_rx_token}",
                 }
-                logger.info(f"zzz: workspace_api_endpoint = {workspace_api_endpoint}")
-                logger.info(f"zzz: headers = {headers}")
                 get_workspace_details_response = requests.get(workspace_api_endpoint, headers=headers)
 
                 # GOOD response from Workspace API - use the details

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -140,7 +140,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 }
                 logger.info(f"zzz: workspace_api_endpoint = {workspace_api_endpoint}")
                 logger.info(f"zzz: headers = {headers}")
-                get_workspace_details_response = requests.get(workspace_api_endpoint, headers=headers, trust_env=False)
+                get_workspace_details_response = requests.get(workspace_api_endpoint, headers=headers, proxies={})
 
                 # GOOD response from Workspace API - use the details
                 if get_workspace_details_response.ok:
@@ -252,19 +252,19 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                     f"{api_endpoint}/register-json",
                     json=collection_dict,
                     headers=headers,
-                    trust_env=False,
+                    proxies={},
                 )
                 logger.info(f"Register collection response: {r.status_code}")
 
                 # TODO pool the catalog until the collection is available
                 #self.feature_collection = requests.get(
-                #    f"{api_endpoint}/collections/{collection.id}", headers=headers, trust_env=False
+                #    f"{api_endpoint}/collections/{collection.id}", headers=headers, proxies={}
                 #).json()
             
                 logger.info(f"Register processing results to collection")
                 r = requests.post(f"{api_endpoint}/register",
                                 json={"type": "stac-item", "url": collection.get_self_href()},
-                                headers=headers, trust_env=False)
+                                headers=headers, proxies={})
                 logger.info(f"Register processing results response: {r.status_code}")
 
         except Exception as e:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -140,7 +140,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 }
                 logger.info(f"zzz: workspace_api_endpoint = {workspace_api_endpoint}")
                 logger.info(f"zzz: headers = {headers}")
-                get_workspace_details_response = requests.get(workspace_api_endpoint, headers=headers, proxies={})
+                get_workspace_details_response = requests.get(workspace_api_endpoint, headers=headers, trust_env=False)
 
                 # GOOD response from Workspace API - use the details
                 if get_workspace_details_response.ok:
@@ -252,19 +252,19 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                     f"{api_endpoint}/register-json",
                     json=collection_dict,
                     headers=headers,
-                    proxies={},
+                    trust_env=False,
                 )
                 logger.info(f"Register collection response: {r.status_code}")
 
                 # TODO pool the catalog until the collection is available
                 #self.feature_collection = requests.get(
-                #    f"{api_endpoint}/collections/{collection.id}", headers=headers, proxies={}
+                #    f"{api_endpoint}/collections/{collection.id}", headers=headers, trust_env=False
                 #).json()
             
                 logger.info(f"Register processing results to collection")
                 r = requests.post(f"{api_endpoint}/register",
                                 json={"type": "stac-item", "url": collection.get_self_href()},
-                                headers=headers, proxies={})
+                                headers=headers, trust_env=False)
                 logger.info(f"Register processing results response: {r.status_code}")
 
         except Exception as e:

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -140,7 +140,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                 }
                 logger.info(f"zzz: workspace_api_endpoint = {workspace_api_endpoint}")
                 logger.info(f"zzz: headers = {headers}")
-                get_workspace_details_response = requests.get(workspace_api_endpoint, headers=headers, proxies={})
+                get_workspace_details_response = requests.get(workspace_api_endpoint, headers=headers)
 
                 # GOOD response from Workspace API - use the details
                 if get_workspace_details_response.ok:
@@ -252,19 +252,18 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                     f"{api_endpoint}/register-json",
                     json=collection_dict,
                     headers=headers,
-                    proxies={},
                 )
                 logger.info(f"Register collection response: {r.status_code}")
 
                 # TODO pool the catalog until the collection is available
                 #self.feature_collection = requests.get(
-                #    f"{api_endpoint}/collections/{collection.id}", headers=headers, proxies={}
+                #    f"{api_endpoint}/collections/{collection.id}", headers=headers
                 #).json()
             
                 logger.info(f"Register processing results to collection")
                 r = requests.post(f"{api_endpoint}/register",
                                 json={"type": "stac-item", "url": collection.get_self_href()},
-                                headers=headers, proxies={})
+                                headers=headers,)
                 logger.info(f"Register processing results response: {r.status_code}")
 
         except Exception as e:
@@ -276,15 +275,13 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             self.restore_http_proxy_env()
 
     def unset_http_proxy_env(self):
-        # http_proxy = os.environ.pop("HTTP_PROXY", None)
-        # logger.info(f"Unsetting env HTTP_PROXY, whose value was {http_proxy}")
-        pass
+        http_proxy = os.environ.pop("HTTP_PROXY", None)
+        logger.info(f"Unsetting env HTTP_PROXY, whose value was {http_proxy}")
 
     def restore_http_proxy_env(self):
-        # if self.http_proxy_env:
-        #     os.environ["HTTP_PROXY"] = self.http_proxy_env
-        #     logger.info(f"Restoring env HTTP_PROXY, to value {self.http_proxy_env}")
-        pass
+        if self.http_proxy_env:
+            os.environ["HTTP_PROXY"] = self.http_proxy_env
+            logger.info(f"Restoring env HTTP_PROXY, to value {self.http_proxy_env}")
 
     @staticmethod
     def init_config_defaults(conf):

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -135,6 +135,8 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
                     "accept": "application/json",
                     "Authorization": f"Bearer {self.ades_rx_token}",
                 }
+                logger.info(f"zzz: workspace_api_endpoint = {workspace_api_endpoint}")
+                logger.info(f"zzz: headers = {headers}")
                 get_workspace_details_response = requests.get(workspace_api_endpoint, headers=headers)
 
                 # GOOD response from Workspace API - use the details

--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -274,7 +274,7 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
         conf["additional_parameters"]["STAGEOUT_AWS_ACCESS_KEY_ID"] = os.environ.get("STAGEOUT_AWS_ACCESS_KEY_ID", "minio-admin")
         conf["additional_parameters"]["STAGEOUT_AWS_SECRET_ACCESS_KEY"] = os.environ.get("STAGEOUT_AWS_SECRET_ACCESS_KEY", "minio-secret-password")
         conf["additional_parameters"]["STAGEOUT_AWS_REGION"] = os.environ.get("STAGEOUT_AWS_REGION", "RegionOne")
-        conf["additional_parameters"]["STAGEOUT_OUTPUT"] = os.environ.get("STAGEOUT_OUTPUT", "processingresults")
+        conf["additional_parameters"]["STAGEOUT_OUTPUT"] = os.environ.get("STAGEOUT_OUTPUT", "eoepca")
 
         # DEBUG
         # logger.info(f"init_config_defaults: additional_parameters...\n{json.dumps(conf['additional_parameters'], indent=2)}\n")


### PR DESCRIPTION
Fixes for problems found during integration...
* pass the url of the workspace-api as a parameter through the helm values
* suppress the HTTP_PROXY (found in the `zoofpm` pod) during interactions with the workspace-api endpoint