### PR TITLE
Modifications to support all application-package-patterns

### DIFF
--- a/{{cookiecutter.service_name}}/service.py
+++ b/{{cookiecutter.service_name}}/service.py
@@ -418,7 +418,6 @@ class EoepcaCalrissianRunnerExecutionHandler(ExecutionHandler):
             logger.info("handle_outputs")
 
             # link element to add to the statusInfo
-            self.conf['main']['tmpUrl']=self.conf['main']['tmpUrl'].replace("temp/",self.conf["auth_env"]["user"]+"/temp/")
             servicesLogs = [
                 {
                     "url": os.path.join(self.conf['main']['tmpUrl'],
@@ -512,7 +511,7 @@ def {{cookiecutter.workflow_id |replace("-", "_")  }}(conf, inputs, outputs): # 
             if "length" in conf["service_logs"]:
                 for i in range(len(keys)):
                     keys[i]+="_"+str(int(conf["service_logs"]["length"]))
-            conf["service_logs"][keys[0]]=os.path.join(conf['main']['tmpUrl'].replace("temp/",conf["auth_env"]["user"]+"/temp/"),
+            conf["service_logs"][keys[0]]=os.path.join(conf['main']['tmpUrl'],
                     runner.get_namespace_name(),
                     "job.log")
             conf["service_logs"][keys[1]]="Job pod log"


### PR DESCRIPTION
This pull request introduces improvements and refactors to the service execution handler logic, focusing on more robust output handling. The main changes include passing outputs to the execution handler and a comprehensive update to the post-execution hook for handling outputs.

**Output Handling and Execution Flow:**
* The `EoepcaCalrissianRunnerExecutionHandler` class now takes `outputs` as an argument, allowing it to directly manage and update output values throughout the execution process. 
* In the workflow function, outputs are now set based on the presence of a `collection` key, ensuring that the correct data is serialized and assigned.

**STAC Catalog and Collection Processing:**
* The `post_execution_hook` method has been refactored to iterate over all outputs, log their state, and handle cases where outputs lack a `mimeType`. Outputs with a `mimeType` are processed via the new `setOutput` method, which loads STAC catalogs, extracts collections or items, and ensures the output collection is correctly built and assigned. 
* The new `setOutput` method robustly handles various STAC catalog structures, falling back to items if collections are missing, and logs detailed information for debugging.

Reference: https://github.com/EOEPCA/roadmap/issues/455